### PR TITLE
Add env storage, add retries to HTTP requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ Token dispenser uses [spark framework](http://sparkjava.com/). To configure netw
 
 #### Storage
 
-There are two storage options supported:
+There are three storage options supported:
 * **Plain text** Set `storage` to `plaintext` to use it. `storage-plaintext-path` property is used to store filesystem path to a plain text file with email-password pairs. There is an example [here](/passwords/passwords.txt). Securing it is up to you.
 * **MongoDB** Set `storage` to `mongodb` to use it. Configurable parameters are self-explanatory.
+* **Environment** Set `storage` to `env` to use it. Set the environment variables `TOKEN_EMAIL` and `TOKEN_PASSWORD` before starting Token dispenser. (Only one email/account is supported.)
 
 ### Usage
 Once server is configured, you can get the tokens for **regular requests** at http://server-address:port/token/email/youremail@gmail.com

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.github.yeriomin</groupId>
             <artifactId>play-store-api</artifactId>
-            <version>0.29</version>
+            <version>0.44.2</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/src/main/java/com/github/yeriomin/tokendispenser/PasswordsDbEnv.java
+++ b/src/main/java/com/github/yeriomin/tokendispenser/PasswordsDbEnv.java
@@ -1,0 +1,34 @@
+package com.github.yeriomin.tokendispenser;
+
+import java.util.Properties;
+
+public class PasswordsDbEnv implements PasswordsDbInterface {
+  private String email;
+  private String password;
+  
+  PasswordsDbEnv(Properties config) {
+    email = System.getenv(Server.ENV_EMAIL);
+    password = System.getenv(Server.ENV_PASSWORD);
+    if (email == null || password == null) {
+      throw new IllegalArgumentException("empty email/password, make sure to set " + Server.ENV_EMAIL + " and " + Server.ENV_PASSWORD);
+    }
+  }
+  
+  @Override
+  public String getRandomEmail() {
+    return email;
+  }
+  
+  @Override
+  public String get(String email) {
+    if (!email.equals(this.email)) {
+      throw new IllegalArgumentException("invalid email: " + email);
+    }
+    return password;
+  }
+  
+  @Override
+  public void put(String email, String password) {
+    throw new UnsupportedOperationException("put is not supported for env storage");
+  }
+}

--- a/src/main/java/com/github/yeriomin/tokendispenser/PasswordsDbFactory.java
+++ b/src/main/java/com/github/yeriomin/tokendispenser/PasswordsDbFactory.java
@@ -9,6 +9,8 @@ public class PasswordsDbFactory {
         Server.LOG.info("Initializing storage type " + storage);
         if (storage.equals(Server.STORAGE_MONGODB)) {
             return new PasswordsDbMongo(config);
+        } else if(storage.equals(Server.STORAGE_ENV)) {
+            return new PasswordsDbEnv(config);
         } else {
             return new PasswordsDbPlaintext(config);
         }

--- a/src/main/java/com/github/yeriomin/tokendispenser/Server.java
+++ b/src/main/java/com/github/yeriomin/tokendispenser/Server.java
@@ -34,7 +34,11 @@ public class Server {
 
     static public final String STORAGE_MONGODB = "mongodb";
     static public final String STORAGE_PLAINTEXT = "plaintext";
-
+    static public final String STORAGE_ENV = "env";
+    
+    static public final String ENV_EMAIL = "TOKEN_EMAIL";
+    static public final String ENV_PASSWORD = "TOKEN_PASSWORD";
+    
     static PasswordsDbInterface passwords;
 
     public static void main(String[] args) {

--- a/src/main/java/com/github/yeriomin/tokendispenser/TokenAc2dmGsfIdResource.java
+++ b/src/main/java/com/github/yeriomin/tokendispenser/TokenAc2dmGsfIdResource.java
@@ -35,7 +35,7 @@ public class TokenAc2dmGsfIdResource extends TokenAc2dmResource {
                 code = e.getCode();
             }
             message = e.getMessage();
-            Server.LOG.warn(e.getClass().getName() + ": " + message);
+            Server.LOG.warn(e.getClass().getName() + ": " + message + (e.getRawResponse() != null ? (" body: " + new String(e.getRawResponse())) : ""));
             halt(code, message);
         } catch (IOException e) {
             message = e.getMessage();

--- a/src/main/java/com/github/yeriomin/tokendispenser/TokenAc2dmResource.java
+++ b/src/main/java/com/github/yeriomin/tokendispenser/TokenAc2dmResource.java
@@ -31,7 +31,7 @@ public class TokenAc2dmResource {
                 code = e.getCode();
             }
             message = e.getMessage();
-            Server.LOG.warn(e.getClass().getName() + ": " + message);
+            Server.LOG.warn(e.getClass().getName() + ": " + message + (e.getRawResponse() != null ? (" body: " + new String(e.getRawResponse())) : ""));
             halt(code, message);
         } catch (IOException e) {
             message = e.getMessage();


### PR DESCRIPTION
- Update play-store-api to 0.44.2
- Retry all HTTP requests up to 8 times on errors
- Print response bodies on request errors
- Add environment storage, using envrionment variables
  TOKEN_EMAIL and TOKEN_PASSWORD for authentication.

(OkHttpClientAdapter was updated by downloading the newest version from [the play-store-api repo](https://github.com/yeriomin/play-store-api/blob/923b402cab7628ff3fe205a71441cd5185a8e97c/src/test/java/com/github/yeriomin/playstoreapi/OkHttpClientAdapter.java), and replacing `System.out.println` with calls to the logger.